### PR TITLE
open browser with path for little ease of use improvement ;) 

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,4 +17,7 @@ export default defineConfig({
          },
       },
    },
+   server: {
+      open: "/realtime-planet-shader/earth/"
+   }
 });


### PR DESCRIPTION
Just adding the right path to open in the browser because vite just outputs the base path and not $basepath + /earth. 